### PR TITLE
kcheck: support searching by kline mask glob

### DIFF
--- a/beryllia/__init__.py
+++ b/beryllia/__init__.py
@@ -371,6 +371,8 @@ class Server(BaseServer):
             elif type == "host":
                 klines_ += await db.kline_kill.find_by_host(query)
                 klines_ += await db.kline_reject.find_by_host(query)
+            elif type == "mask":
+                klines_ += await db.kline.find_by_mask_glob(query)
             elif type == "ts":
                 if (dt := try_parse_ts(queryv)) is not None:
                     klines_ += await db.kline.find_by_ts(dt)

--- a/beryllia/normalise.py
+++ b/beryllia/normalise.py
@@ -28,14 +28,26 @@ class RFC1459SearchNormaliser(SearchNormaliser):
             ) -> CompositeString:
 
         out = CompositeString()
+        seen_chars: Set[int] = set()
         for part in input:
             if part.type == CompositeStringType.TEXT:
-                if type in {
-                        SearchType.NICK, SearchType.USER, SearchType.MASK}:
+                if type in {SearchType.NICK, SearchType.USER}:
                     text = casefold("rfc1459", part.text)
+                elif type == SearchType.MASK:
+                    if ord("@") in seen_chars:
+                        text = part.text.lower()
+                    elif not "@" in part.text:
+                        text = casefold("rfc1459", part.text)
+                    else:
+                        user, _, host = part.text.partition("@")
+                        text = casefold("rfc1459", user)
+                        text += "@"
+                        text += host.casefold
                 else:
                     text = part.text.lower()
+
                 out.append(CompositeStringText(text))
+                seen_chars.update(ord(c) for c in part.text)
             else:
                 out.append(part)
         return out

--- a/beryllia/normalise.py
+++ b/beryllia/normalise.py
@@ -12,6 +12,7 @@ class SearchType(Enum):
     REAL = 3
     HOST = 4
     TAG  = 5
+    MASK = 6
 
 class SearchNormaliser(object):
     def normalise(self,
@@ -29,7 +30,8 @@ class RFC1459SearchNormaliser(SearchNormaliser):
         out = CompositeString()
         for part in input:
             if part.type == CompositeStringType.TEXT:
-                if type in {SearchType.NICK, SearchType.USER}:
+                if type in {
+                        SearchType.NICK, SearchType.USER, SearchType.MASK}:
                     text = casefold("rfc1459", part.text)
                 else:
                     text = part.text.lower()

--- a/make-database.sql
+++ b/make-database.sql
@@ -9,14 +9,15 @@
 BEGIN;
 
 CREATE TABLE kline (
-    id       SERIAL PRIMARY KEY,
-    mask     VARCHAR(92)  NOT NULL,
-    source   VARCHAR(92)  NOT NULL,
-    oper     VARCHAR(16)  NOT NULL,
-    duration INT          NOT NULL,
-    reason   VARCHAR(260) NOT NULL,
-    ts       TIMESTAMP    NOT NULL,
-    expire   TIMESTAMP    NOT NULL
+    id          SERIAL PRIMARY KEY,
+    mask        VARCHAR(92)  NOT NULL,
+    search_mask VARCHAR(92)  NOT NULL,
+    source      VARCHAR(92)  NOT NULL,
+    oper        VARCHAR(16)  NOT NULL,
+    duration    INT          NOT NULL,
+    reason      VARCHAR(260) NOT NULL,
+    ts          TIMESTAMP    NOT NULL,
+    expire      TIMESTAMP    NOT NULL
 );
 -- for retention period bulk deletion
 CREATE INDEX kline_expire ON kline(expire);


### PR DESCRIPTION
small data migration required:

```
> ALTER TABLE kline ADD COLUMN search_mask VARCHAR(92);
```
```python
import psycopg2, ircstates
db = psycopg2.connect(user="beryllia")
cursor = db.cursor()

cursor.execute("SELECT id, mask FROM kline")
for id, mask in cursor.fetchall():
    user, sep, host = mask.partition("@")
    search_mask = ircstates.casefold("rfc1459", user)
    search_mask += "@"
    search_mask += host.lower()

    cursor.execute("""
        UPDATE kline
        SET search_mask=%s
        WHERE id=%s
    """, [search_mask, id])
db.commit()
```
```
> ALTER TABLE kline ALTER COLUMN search_mask SET NOT NULL;
```
